### PR TITLE
fix redoc url

### DIFF
--- a/docs/openAPI/index.html
+++ b/docs/openAPI/index.html
@@ -19,6 +19,6 @@
 </head>
 <body>
 <redoc spec-url='/api/doc/api.yaml'></redoc>
-<script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
+<script src="https://cdn.jsdelivr.net/npm/redoc@2/bundles/redoc.standalone.js"> </script>
 </body>
 </html>


### PR DESCRIPTION
the current link redoc.standalone.js ends in a 404, pinning it to Version 2 fixes it