### PR TITLE
small matching improvements for at-addresses

### DIFF
--- a/internal/nominatim/types.go
+++ b/internal/nominatim/types.go
@@ -88,6 +88,7 @@ func (nr *NominatimCoreResult) parse() ParsedResult {
 	}
 	if len(nr.IsolatedDwelling) > 0 {
 		p.City = append(p.City, nr.IsolatedDwelling)
+		p.Street = append(p.Street, nr.IsolatedDwelling)
 	}
 	if len(nr.Neighbourhood) > 0 {
 		p.City = append(p.City, nr.Neighbourhood)

--- a/internal/normalization/at.go
+++ b/internal/normalization/at.go
@@ -92,6 +92,7 @@ func (at *AT) Street(s string) ([]string, error) {
 	s = strings.ReplaceAll(s, "strasze", "strasse")
 	s = strings.ReplaceAll(s, "chau.", "chaussee")
 	s = strings.ReplaceAll(s, "rd.", "road")
+	s = strings.ReplaceAll(s, "wr.", "wiener")
 	s = at.reCrap.ReplaceAllString(s, " ")
 	s = strings.ReplaceAll(s, "ü", "ue")
 	s = strings.ReplaceAll(s, "ä", "ae")


### PR DESCRIPTION
This PR adds some small improvements fro at-address:

- IsolatedDwelling is often used as street replacement (not only as city replacement)
- `wr.`  is an often used shortcut for `wiener`